### PR TITLE
Stops the first Trade Perk pairs from breaking comparison colors

### DIFF
--- a/Patches/ColorComparisonPatch.cs
+++ b/Patches/ColorComparisonPatch.cs
@@ -1,0 +1,59 @@
+﻿using HarmonyLib;
+using System;
+using System.Reflection;
+using TaleWorlds.CampaignSystem.ViewModelCollection;
+using TaleWorlds.Library;
+
+namespace BannerlordTweaks.Patches
+{
+	[HarmonyPatch]
+	public class ColorComparisonPatch
+    {
+		//To inject into the private method GetColorFromComparison
+		static MethodBase TargetMethod()
+		{
+			return AccessTools.Method(
+				typeof(ItemMenuVM),
+						"GetColorFromComparison",
+				new Type[] { typeof(int), typeof(bool) }
+			);
+		}
+
+		//Replace the entire method
+		static bool Prefix(ItemMenuVM __instance, int result, bool isCompared, ref Color __result)
+		{
+			//if (MobileParty.MainParty != null && (MobileParty.MainParty.HasPerk(DefaultPerks.Trade.WholeSeller) || MobileParty.MainParty.HasPerk(DefaultPerks.Trade.Appraiser)))
+			//{
+			//	return Colors.Black;
+			//}
+
+			// Code above is from original method, the intention was probably to turn on red/green colours on the purchase price of any goods in your inventory as the Perk says "Profits are marked"
+			// But this function is also used for equipment stat comparisons, so this is the wrong place to enable those perks.
+			if (result != -1)
+			{
+				if (result != 1)
+				{
+					__result = Colors.Black;
+					return false;
+				}
+				if (!isCompared)
+				{
+					__result = UIColors.PositiveIndicator;
+					return false;
+				}
+				__result = UIColors.NegativeIndicator;
+				return false;
+			}
+			else
+			{
+				if (!isCompared)
+				{
+					__result = UIColors.NegativeIndicator;
+					return false;
+				}
+				__result = UIColors.PositiveIndicator;
+				return false;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Due to some wrong code either of the first Trade Perks broke the red/green coloring of stats when comparing two different items. That's now fixed.